### PR TITLE
Feat/vehicle registration

### DIFF
--- a/lib/facility.rb
+++ b/lib/facility.rb
@@ -3,7 +3,8 @@ class Facility
               :address, 
               :phone, 
               :services, 
-              :registered_vehicles
+              :registered_vehicles,
+              :collected_fees
 
   def initialize(info)
     @name = info[:name]
@@ -11,6 +12,7 @@ class Facility
     @phone = info[:phone]
     @services = []
     @registered_vehicles = []
+    @collected_fees = 0
   end
 
   def add_service(service)
@@ -20,6 +22,7 @@ class Facility
   def register_vehicle(vehicle)
     vehicle.registration_date = Date.today
     plate_maker(vehicle)
+    fee_collector(vehicle)
     @registered_vehicles << vehicle
   end
 
@@ -30,6 +33,16 @@ class Facility
       vehicle.plate_type = :ev
     else
       vehicle.plate_type = :regular
+    end
+  end
+
+  def fee_collector(vehicle)
+    if vehicle.plate_type == :antique
+      @collected_fees += 25
+    elsif vehicle.plate_type == :ev
+      @collected_fees += 200
+    else
+      @collected_fees += 100
     end
   end
 end

--- a/lib/facility.rb
+++ b/lib/facility.rb
@@ -18,6 +18,7 @@ class Facility
   end
 
   def register_vehicle(vehicle)
+    vehicle.registration_date = Date.today
     @registered_vehicles << vehicle
   end
 end

--- a/lib/facility.rb
+++ b/lib/facility.rb
@@ -1,14 +1,23 @@
 class Facility
-  attr_reader :name, :address, :phone, :services
+  attr_reader :name, 
+              :address, 
+              :phone, 
+              :services, 
+              :registered_vehicles
 
   def initialize(info)
     @name = info[:name]
     @address = info[:address]
     @phone = info[:phone]
     @services = []
+    @registered_vehicles = []
   end
 
   def add_service(service)
     @services << service
+  end
+
+  def register_vehicle(vehicle)
+    @registered_vehicles << vehicle
   end
 end

--- a/lib/facility.rb
+++ b/lib/facility.rb
@@ -19,6 +19,7 @@ class Facility
 
   def register_vehicle(vehicle)
     vehicle.registration_date = Date.today
+    vehicle.plate_type = :regular
     @registered_vehicles << vehicle
   end
 end

--- a/lib/facility.rb
+++ b/lib/facility.rb
@@ -19,7 +19,17 @@ class Facility
 
   def register_vehicle(vehicle)
     vehicle.registration_date = Date.today
-    vehicle.plate_type = :regular
+    plate_maker(vehicle)
     @registered_vehicles << vehicle
+  end
+
+  def plate_maker(vehicle)
+    if vehicle.antique?
+      vehicle.plate_type = :antique
+    elsif vehicle.engine == :ev
+      vehicle.plate_type = :ev
+    else
+      vehicle.plate_type = :regular
+    end
   end
 end

--- a/lib/vehicle.rb
+++ b/lib/vehicle.rb
@@ -5,8 +5,9 @@ class Vehicle
               :year,
               :make,
               :model,
-              :engine,
-              :registration_date
+              :engine
+
+  attr_accessor :registration_date
 
   def initialize(vehicle_details)
     @vin = vehicle_details[:vin]

--- a/lib/vehicle.rb
+++ b/lib/vehicle.rb
@@ -7,7 +7,8 @@ class Vehicle
               :model,
               :engine
 
-  attr_accessor :registration_date
+  attr_accessor :registration_date,
+                :plate_type
 
   def initialize(vehicle_details)
     @vin = vehicle_details[:vin]
@@ -16,6 +17,7 @@ class Vehicle
     @model = vehicle_details[:model]
     @engine = vehicle_details[:engine]
     @registration_date = vehicle_details[:registration_date]
+    @plate_type = vehicle_details[:plate_type]
   end
 
   def antique?

--- a/spec/facility_spec.rb
+++ b/spec/facility_spec.rb
@@ -24,6 +24,32 @@ RSpec.describe Facility do
     end
   end
 
+  describe '#plate_maker' do
+    it 'makes an antique plate when vehicle is over 25 years old' do
+      camaro = Vehicle.new({vin: '1a2b3c4d5e6f', year: 1969, make: 'Chevrolet', model: 'Camaro', engine: :ice})
+
+      @facility.plate_maker(camaro)
+
+      expect(camaro.plate_type).to eq(:antique)
+    end
+
+    it 'makes an ev plate when vehicle is an ev engine' do
+      bolt = Vehicle.new({vin: '987654321abcdefgh', year: 2019, make: 'Chevrolet', model: 'Bolt', engine: :ev})
+
+      @facility.plate_maker(bolt)
+
+      expect(bolt.plate_type).to eq(:ev)
+    end
+
+    it 'makes a regular plate when a vehicle is newer than 25 years and is not an ev engine' do
+      cruz = Vehicle.new({vin: '123456789abcdefgh', year: 2012, make: 'Chevrolet', model: 'Cruz', engine: :ice})
+
+      @facility.plate_maker(cruz)
+
+      expect(cruz.plate_type).to eq(:regular)
+    end
+  end
+
   describe '#register_vehicle' do
     it 'starts with no registered vehicles' do
       expect(@facility.registered_vehicles).to eq([])
@@ -70,37 +96,71 @@ RSpec.describe Facility do
     end
   end
 
-  describe '#plate_maker' do
-    it 'makes an antique plate when vehicle is over 25 years old' do
-      camaro = Vehicle.new({vin: '1a2b3c4d5e6f', year: 1969, make: 'Chevrolet', model: 'Camaro', engine: :ice})
-
-      @facility.plate_maker(camaro)
-
-      expect(camaro.plate_type).to eq(:antique)
+  describe '#collected_fees'
+    it 'starts with no collected fees' do
+      expect(@facility.collected_fees).to eq(0)
     end
 
-    it 'makes an ev plate when vehicle is an ev engine' do
-      bolt = Vehicle.new({vin: '987654321abcdefgh', year: 2019, make: 'Chevrolet', model: 'Bolt', engine: :ev})
-
-      @facility.plate_maker(bolt)
-
-      expect(bolt.plate_type).to eq(:ev)
-    end
-
-    it 'makes a regular plate when a vehicle is newer than 25 years and is not an ev engine' do
+    it 'collects 100 dollars when registering a car with :regular plates' do
       cruz = Vehicle.new({vin: '123456789abcdefgh', year: 2012, make: 'Chevrolet', model: 'Cruz', engine: :ice})
 
-      @facility.plate_maker(cruz)
+      @facility.register_vehicle(cruz)
 
-      expect(cruz.plate_type).to eq(:regular)
+      expect(@facility.collected_fees).to eq(100)
+    end
+
+    it 'collects 25 dollars when registering a car with :antique plates' do
+      camaro = Vehicle.new({vin: '1a2b3c4d5e6f', year: 1969, make: 'Chevrolet', model: 'Camaro', engine: :ice})
+
+      @facility.register_vehicle(camaro)
+
+      expect(@facility.collected_fees).to eq(25)
+    end
+
+    it 'collects 200 dollars when registering a car with :ev plates' do
+      bolt = Vehicle.new({vin: '987654321abcdefgh', year: 2019, make: 'Chevrolet', model: 'Bolt', engine: :ev})
+
+      @facility.register_vehicle(bolt)
+
+      expect(bolt.collected_fees).to eq(:200)
+    end
+
+    it 'can collects fees from multiple registrations' do
+      bolt = Vehicle.new({vin: '987654321abcdefgh', year: 2019, make: 'Chevrolet', model: 'Bolt', engine: :ev})
+      camaro = Vehicle.new({vin: '1a2b3c4d5e6f', year: 1969, make: 'Chevrolet', model: 'Camaro', engine: :ice})
+      cruz = Vehicle.new({vin: '123456789abcdefgh', year: 2012, make: 'Chevrolet', model: 'Cruz', engine: :ice})
+
+      @facility.register_vehicle(bolt)
+      @facility.register_vehicle(camaro)
+      @facility.register_vehicle(cruz)
+
+      expect(@facility.collected_fees).to eq(325)
     end
   end
 
-    # it 'collects 100 dollars when registering a car with :regular plates' do
-    #   cruz = Vehicle.new({vin: '1a2b3c4d5e6f', year: 1969, make: 'Chevrolet', model: 'Camaro', engine: :ice})
+  describe '#fee_collector' do
+    it 'collects 100 dollars when registering a car with :regular plates' do
+      cruz = Vehicle.new({vin: '123456789abcdefgh', year: 2012, make: 'Chevrolet', model: 'Cruz', engine: :ice})
 
-    #   @facility.register_vehicle(cruz)
+      @facility.fee_collector(cruz)
 
-    #   expect(@facility.collected_fees).to eq(100)
-    # end
+      expect(@facility.collected_fees).to eq(100)
+    end
+
+    it 'collects 25 dollars when registering a car with :antique plates' do
+      camaro = Vehicle.new({vin: '1a2b3c4d5e6f', year: 1969, make: 'Chevrolet', model: 'Camaro', engine: :ice})
+
+      @facility.fee_collector(camaro)
+
+      expect(@facility.collected_fees).to eq(25)
+    end
+
+    it 'collects 200 dollars when registering a car with :ev plates' do
+      bolt = Vehicle.new({vin: '987654321abcdefgh', year: 2019, make: 'Chevrolet', model: 'Bolt', engine: :ev})
+
+      @facility.register_vehicle(bolt)
+
+      expect(bolt.collected_fees).to eq(:200)
+    end
+  end
 end

--- a/spec/facility_spec.rb
+++ b/spec/facility_spec.rb
@@ -45,12 +45,36 @@ RSpec.describe Facility do
       expect(cruz.registration_date).to eq(Date.today)
     end
 
-    it 'gives a vehicle default plate type of regular when registered' do
+    it 'gives a vehicle a plate type of :regular when registered as an :ice engine' do
       cruz = Vehicle.new({vin: '1a2b3c4d5e6f', year: 1969, make: 'Chevrolet', model: 'Camaro', engine: :ice})
 
       @facility.register_vehicle(cruz)
 
       expect(cruz.plate_type).to eq(:regular)
     end
+
+    it 'gives a vehicle a plate type of :antique when registered if vehicle is over 25 years old' do
+      camaro = Vehicle.new({vin: '1a2b3c4d5e6f', year: 1969, make: 'Chevrolet', model: 'Camaro', engine: :ice})
+
+      @facility.register_vehicle(camaro)
+
+      expect(camaro.plate_type).to eq(:antique)
+    end
+
+    it 'gives a vehicle a plate type of :ev when registered if vehicle has :ev engine:' do
+      bolt = Vehicle.new({vin: '987654321abcdefgh', year: 2019, make: 'Chevrolet', model: 'Bolt', engine: :ev} )
+
+      @facility.register_vehicle(bolt)
+
+      expect(bolt.plate_type).to eq(:ev)
+    end
+
+    # it 'collects 100 dollars when registering a car with :regular plates' do
+    #   cruz = Vehicle.new({vin: '1a2b3c4d5e6f', year: 1969, make: 'Chevrolet', model: 'Camaro', engine: :ice})
+
+    #   @facility.register_vehicle(cruz)
+
+    #   expect(@facility.collected_fees).to eq(100)
+    # end
   end
 end

--- a/spec/facility_spec.rb
+++ b/spec/facility_spec.rb
@@ -23,4 +23,18 @@ RSpec.describe Facility do
       expect(@facility.services).to eq(['New Drivers License', 'Renew Drivers License', 'Vehicle Registration'])
     end
   end
+
+  describe '#register_vehicle' do
+    it 'starts with no registered vehicles' do
+      expect(@facility.registered_vehicles).to eq([])
+    end
+
+    it 'can keep track of a vehicle it has registered' do
+      cruz = Vehicle.new({vin: '1a2b3c4d5e6f', year: 1969, make: 'Chevrolet', model: 'Camaro', engine: :ice})
+
+      @facility.register_vehicle(cruz)
+
+      expect(@facility.registered_vehicles).to eq([cruz])
+    end
+  end
 end

--- a/spec/facility_spec.rb
+++ b/spec/facility_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Facility do
     end
 
     it 'can keep track of a vehicle it has registered' do
-      cruz = Vehicle.new({vin: '1a2b3c4d5e6f', year: 1969, make: 'Chevrolet', model: 'Camaro', engine: :ice})
+      cruz = Vehicle.new({vin: '123456789abcdefgh', year: 2012, make: 'Chevrolet', model: 'Cruz', engine: :ice})
 
       @facility.register_vehicle(cruz)
 
@@ -38,7 +38,7 @@ RSpec.describe Facility do
     end
 
     it 'gives a vehicle a registration date when registered' do
-      cruz = Vehicle.new({vin: '1a2b3c4d5e6f', year: 1969, make: 'Chevrolet', model: 'Camaro', engine: :ice})
+      cruz = Vehicle.new({vin: '123456789abcdefgh', year: 2012, make: 'Chevrolet', model: 'Cruz', engine: :ice})
 
       @facility.register_vehicle(cruz)
 
@@ -46,7 +46,7 @@ RSpec.describe Facility do
     end
 
     it 'gives a vehicle a plate type of :regular when registered as an :ice engine' do
-      cruz = Vehicle.new({vin: '1a2b3c4d5e6f', year: 1969, make: 'Chevrolet', model: 'Camaro', engine: :ice})
+      cruz = Vehicle.new({vin: '123456789abcdefgh', year: 2012, make: 'Chevrolet', model: 'Cruz', engine: :ice})
 
       @facility.register_vehicle(cruz)
 
@@ -62,12 +62,39 @@ RSpec.describe Facility do
     end
 
     it 'gives a vehicle a plate type of :ev when registered if vehicle has :ev engine:' do
-      bolt = Vehicle.new({vin: '987654321abcdefgh', year: 2019, make: 'Chevrolet', model: 'Bolt', engine: :ev} )
+      bolt = Vehicle.new({vin: '987654321abcdefgh', year: 2019, make: 'Chevrolet', model: 'Bolt', engine: :ev})
 
       @facility.register_vehicle(bolt)
 
       expect(bolt.plate_type).to eq(:ev)
     end
+  end
+
+  describe '#plate_maker' do
+    it 'makes an antique plate when vehicle is over 25 years old' do
+      camaro = Vehicle.new({vin: '1a2b3c4d5e6f', year: 1969, make: 'Chevrolet', model: 'Camaro', engine: :ice})
+
+      plate_maker(camaro)
+
+      expect(camaro.plate_type).to eq(:antique)
+    end
+
+    it 'makes an ev plate when vehicle is an ev engine' do
+      bolt = Vehicle.new({vin: '987654321abcdefgh', year: 2019, make: 'Chevrolet', model: 'Bolt', engine: :ev})
+
+      plate_maker(bolt)
+
+      expect(bolt.plate_type).to eq(:ev)
+    end
+
+    it 'makes a regular plate when a vehicle is newer than 25 years and is not an ev engine' do
+      cruz = Vehicle.new({vin: '123456789abcdefgh', year: 2012, make: 'Chevrolet', model: 'Cruz', engine: :ice})
+
+      plate_maker(cruz)
+
+      expect(cruz.plate_type).to eq(:regular)
+    end
+  end
 
     # it 'collects 100 dollars when registering a car with :regular plates' do
     #   cruz = Vehicle.new({vin: '1a2b3c4d5e6f', year: 1969, make: 'Chevrolet', model: 'Camaro', engine: :ice})

--- a/spec/facility_spec.rb
+++ b/spec/facility_spec.rb
@@ -37,12 +37,20 @@ RSpec.describe Facility do
       expect(@facility.registered_vehicles).to eq([cruz])
     end
 
-    it 'gives a car a registration date when registered' do
+    it 'gives a vehicle a registration date when registered' do
       cruz = Vehicle.new({vin: '1a2b3c4d5e6f', year: 1969, make: 'Chevrolet', model: 'Camaro', engine: :ice})
 
       @facility.register_vehicle(cruz)
 
       expect(cruz.registration_date).to eq(Date.today)
+    end
+
+    it 'gives a vehicle default plate type of regular when registered' do
+      cruz = Vehicle.new({vin: '1a2b3c4d5e6f', year: 1969, make: 'Chevrolet', model: 'Camaro', engine: :ice})
+
+      @facility.register_vehicle(cruz)
+
+      expect(cruz.plate_type).to eq(:regular)
     end
   end
 end

--- a/spec/facility_spec.rb
+++ b/spec/facility_spec.rb
@@ -36,5 +36,13 @@ RSpec.describe Facility do
 
       expect(@facility.registered_vehicles).to eq([cruz])
     end
+
+    it 'gives a car a registration date when registered' do
+      cruz = Vehicle.new({vin: '1a2b3c4d5e6f', year: 1969, make: 'Chevrolet', model: 'Camaro', engine: :ice})
+
+      @facility.register_vehicle(cruz)
+
+      expect(cruz.registration_date).to eq(Date.today)
+    end
   end
 end

--- a/spec/facility_spec.rb
+++ b/spec/facility_spec.rb
@@ -2,25 +2,29 @@ require 'spec_helper'
 
 RSpec.describe Facility do
   before(:each) do
-    @facility = Facility.new({name: 'DMV Tremont Branch', address: '2855 Tremont Place Suite 118 Denver CO 80205', phone: '(720) 865-4600'})
+    @facility_1 = Facility.new({name: 'DMV Tremont Branch', address: '2855 Tremont Place Suite 118 Denver CO 80205', phone: '(720) 865-4600'})
+    @facility_2 = Facility.new({name: 'DMV Northeast Branch', address: '4685 Peoria Street Suite 101 Denver CO 80239', phone: '(720) 865-4600'})
+    @registrant_1 = Registrant.new('Bruce', 18, true)
+    @registrant_2 = Registrant.new('Penny', 16)
+    @registrant_3 = Registrant.new('Tucker', 15)
   end
   describe '#initialize' do
     it 'can initialize' do
-      expect(@facility).to be_an_instance_of(Facility)
-      expect(@facility.name).to eq('DMV Tremont Branch')
-      expect(@facility.address).to eq('2855 Tremont Place Suite 118 Denver CO 80205')
-      expect(@facility.phone).to eq('(720) 865-4600')
-      expect(@facility.services).to eq([])
+      expect(@facility_1).to be_an_instance_of(Facility)
+      expect(@facility_1.name).to eq('DMV Tremont Branch')
+      expect(@facility_1.address).to eq('2855 Tremont Place Suite 118 Denver CO 80205')
+      expect(@facility_1.phone).to eq('(720) 865-4600')
+      expect(@facility_1.services).to eq([])
     end
   end
 
   describe '#add service' do
     it 'can add available services' do
-      expect(@facility.services).to eq([])
-      @facility.add_service('New Drivers License')
-      @facility.add_service('Renew Drivers License')
-      @facility.add_service('Vehicle Registration')
-      expect(@facility.services).to eq(['New Drivers License', 'Renew Drivers License', 'Vehicle Registration'])
+      expect(@facility_1.services).to eq([])
+      @facility_1.add_service('New Drivers License')
+      @facility_1.add_service('Renew Drivers License')
+      @facility_1.add_service('Vehicle Registration')
+      expect(@facility_1.services).to eq(['New Drivers License', 'Renew Drivers License', 'Vehicle Registration'])
     end
   end
 
@@ -28,7 +32,7 @@ RSpec.describe Facility do
     it 'makes an antique plate when vehicle is over 25 years old' do
       camaro = Vehicle.new({vin: '1a2b3c4d5e6f', year: 1969, make: 'Chevrolet', model: 'Camaro', engine: :ice})
 
-      @facility.plate_maker(camaro)
+      @facility_1.plate_maker(camaro)
 
       expect(camaro.plate_type).to eq(:antique)
     end
@@ -36,7 +40,7 @@ RSpec.describe Facility do
     it 'makes an ev plate when vehicle is an ev engine' do
       bolt = Vehicle.new({vin: '987654321abcdefgh', year: 2019, make: 'Chevrolet', model: 'Bolt', engine: :ev})
 
-      @facility.plate_maker(bolt)
+      @facility_1.plate_maker(bolt)
 
       expect(bolt.plate_type).to eq(:ev)
     end
@@ -44,7 +48,7 @@ RSpec.describe Facility do
     it 'makes a regular plate when a vehicle is newer than 25 years and is not an ev engine' do
       cruz = Vehicle.new({vin: '123456789abcdefgh', year: 2012, make: 'Chevrolet', model: 'Cruz', engine: :ice})
 
-      @facility.plate_maker(cruz)
+      @facility_1.plate_maker(cruz)
 
       expect(cruz.plate_type).to eq(:regular)
     end
@@ -52,21 +56,21 @@ RSpec.describe Facility do
 
   describe '#register_vehicle' do
     it 'starts with no registered vehicles' do
-      expect(@facility.registered_vehicles).to eq([])
+      expect(@facility_1.registered_vehicles).to eq([])
     end
 
     it 'can keep track of a vehicle it has registered' do
       cruz = Vehicle.new({vin: '123456789abcdefgh', year: 2012, make: 'Chevrolet', model: 'Cruz', engine: :ice})
 
-      @facility.register_vehicle(cruz)
+      @facility_1.register_vehicle(cruz)
 
-      expect(@facility.registered_vehicles).to eq([cruz])
+      expect(@facility_1.registered_vehicles).to eq([cruz])
     end
 
     it 'gives a vehicle a registration date when registered' do
       cruz = Vehicle.new({vin: '123456789abcdefgh', year: 2012, make: 'Chevrolet', model: 'Cruz', engine: :ice})
 
-      @facility.register_vehicle(cruz)
+      @facility_1.register_vehicle(cruz)
 
       expect(cruz.registration_date).to eq(Date.today)
     end
@@ -74,7 +78,7 @@ RSpec.describe Facility do
     it 'gives a vehicle a plate type of :regular when registered as an :ice engine' do
       cruz = Vehicle.new({vin: '123456789abcdefgh', year: 2012, make: 'Chevrolet', model: 'Cruz', engine: :ice})
 
-      @facility.register_vehicle(cruz)
+      @facility_1.register_vehicle(cruz)
 
       expect(cruz.plate_type).to eq(:regular)
     end
@@ -82,7 +86,7 @@ RSpec.describe Facility do
     it 'gives a vehicle a plate type of :antique when registered if vehicle is over 25 years old' do
       camaro = Vehicle.new({vin: '1a2b3c4d5e6f', year: 1969, make: 'Chevrolet', model: 'Camaro', engine: :ice})
 
-      @facility.register_vehicle(camaro)
+      @facility_1.register_vehicle(camaro)
 
       expect(camaro.plate_type).to eq(:antique)
     end
@@ -90,7 +94,7 @@ RSpec.describe Facility do
     it 'gives a vehicle a plate type of :ev when registered if vehicle has :ev engine:' do
       bolt = Vehicle.new({vin: '987654321abcdefgh', year: 2019, make: 'Chevrolet', model: 'Bolt', engine: :ev})
 
-      @facility.register_vehicle(bolt)
+      @facility_1.register_vehicle(bolt)
 
       expect(bolt.plate_type).to eq(:ev)
     end
@@ -98,31 +102,31 @@ RSpec.describe Facility do
 
   describe '#collected_fees' do
     it 'starts with no collected fees' do
-      expect(@facility.collected_fees).to eq(0)
+      expect(@facility_1.collected_fees).to eq(0)
     end
 
     it 'collects 100 dollars when registering a car with :regular plates' do
       cruz = Vehicle.new({vin: '123456789abcdefgh', year: 2012, make: 'Chevrolet', model: 'Cruz', engine: :ice})
 
-      @facility.register_vehicle(cruz)
+      @facility_1.register_vehicle(cruz)
 
-      expect(@facility.collected_fees).to eq(100)
+      expect(@facility_1.collected_fees).to eq(100)
     end
 
     it 'collects 25 dollars when registering a car with :antique plates' do
       camaro = Vehicle.new({vin: '1a2b3c4d5e6f', year: 1969, make: 'Chevrolet', model: 'Camaro', engine: :ice})
 
-      @facility.register_vehicle(camaro)
+      @facility_1.register_vehicle(camaro)
 
-      expect(@facility.collected_fees).to eq(25)
+      expect(@facility_1.collected_fees).to eq(25)
     end
 
     it 'collects 200 dollars when registering a car with :ev plates' do
       bolt = Vehicle.new({vin: '987654321abcdefgh', year: 2019, make: 'Chevrolet', model: 'Bolt', engine: :ev})
 
-      @facility.register_vehicle(bolt)
+      @facility_1.register_vehicle(bolt)
 
-      expect(@facility.collected_fees).to eq(200)
+      expect(@facility_1.collected_fees).to eq(200)
     end
 
     it 'can collects fees from multiple registrations' do
@@ -130,11 +134,11 @@ RSpec.describe Facility do
       camaro = Vehicle.new({vin: '1a2b3c4d5e6f', year: 1969, make: 'Chevrolet', model: 'Camaro', engine: :ice})
       cruz = Vehicle.new({vin: '123456789abcdefgh', year: 2012, make: 'Chevrolet', model: 'Cruz', engine: :ice})
 
-      @facility.register_vehicle(bolt)
-      @facility.register_vehicle(camaro)
-      @facility.register_vehicle(cruz)
+      @facility_1.register_vehicle(bolt)
+      @facility_1.register_vehicle(camaro)
+      @facility_1.register_vehicle(cruz)
 
-      expect(@facility.collected_fees).to eq(325)
+      expect(@facility_1.collected_fees).to eq(325)
     end
   end
 
@@ -142,28 +146,74 @@ RSpec.describe Facility do
     it 'collects 100 dollars when registering a car with :regular plates' do
       cruz = Vehicle.new({vin: '123456789abcdefgh', year: 2012, make: 'Chevrolet', model: 'Cruz', engine: :ice})
 
-      @facility.plate_maker(cruz)
-      @facility.fee_collector(cruz)
+      @facility_1.plate_maker(cruz)
+      @facility_1.fee_collector(cruz)
 
-      expect(@facility.collected_fees).to eq(100)
+      expect(@facility_1.collected_fees).to eq(100)
     end
 
     it 'collects 25 dollars when registering a car with :antique plates' do
       camaro = Vehicle.new({vin: '1a2b3c4d5e6f', year: 1969, make: 'Chevrolet', model: 'Camaro', engine: :ice})
 
-      @facility.plate_maker(camaro)
-      @facility.fee_collector(camaro)
+      @facility_1.plate_maker(camaro)
+      @facility_1.fee_collector(camaro)
 
-      expect(@facility.collected_fees).to eq(25)
+      expect(@facility_1.collected_fees).to eq(25)
     end
 
     it 'collects 200 dollars when registering a car with :ev plates' do
       bolt = Vehicle.new({vin: '987654321abcdefgh', year: 2019, make: 'Chevrolet', model: 'Bolt', engine: :ev})
 
-      @facility.plate_maker(bolt)
-      @facility.fee_collector(bolt)
+      @facility_1.plate_maker(bolt)
+      @facility_1.fee_collector(bolt)
 
-      expect(@facility.collected_fees).to eq(200)
+      expect(@facility_1.collected_fees).to eq(200)
     end
   end
+
+  describe '#administer_written_test(registrant)' do
+    it 'can not administer a written test if it does not offer that service' do
+      @facility_1.administer_written_test(@registrant_1)
+
+      expect(@registrant_1[:written]).to eq(false)
+    end
+
+    it 'can not administer a written test to someone without their permit' do
+      @facility_1.administer_written_test(@registrant_2)
+
+      expect(@registrant_2[:written]).to eq(false)
+    end
+
+    it 'can administer a written test to a registrant if it offers the service' do
+      @facility_1.add_service("Written Test")
+
+      @facility_1.administer_written_test(@registrant_1)
+
+      expect(@registrant_1[:written]).to eq(true)
+    end
+
+    it 'can administer a written test to a registrant if it has earned a permit' do
+      @facility_1.add_service("Written Test")
+
+      @registrant_2.earn_permit
+
+      @facility_1.administer_written_test(@registrant_2)
+
+      expect(@registrant_2[:written]).to eq(true)
+    end
+
+    it 'will not administer a written test to someone who is under 16 years old' do
+      @facility_1.add_service("Written Test")
+
+      expect(@registrant_3[:written]).to eq(false)
+
+      @registrant_3.earn_permit
+
+      @facility_1.administer_written_test(@registrant_3)
+
+      expect(@registrant_3[:written]).to eq(false)
+    end
+
+      
+
 end

--- a/spec/facility_spec.rb
+++ b/spec/facility_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe Facility do
     end
   end
 
-  describe '#collected_fees'
+  describe '#collected_fees' do
     it 'starts with no collected fees' do
       expect(@facility.collected_fees).to eq(0)
     end
@@ -122,7 +122,7 @@ RSpec.describe Facility do
 
       @facility.register_vehicle(bolt)
 
-      expect(bolt.collected_fees).to eq(:200)
+      expect(@facility.collected_fees).to eq(200)
     end
 
     it 'can collects fees from multiple registrations' do
@@ -142,6 +142,7 @@ RSpec.describe Facility do
     it 'collects 100 dollars when registering a car with :regular plates' do
       cruz = Vehicle.new({vin: '123456789abcdefgh', year: 2012, make: 'Chevrolet', model: 'Cruz', engine: :ice})
 
+      @facility.plate_maker(cruz)
       @facility.fee_collector(cruz)
 
       expect(@facility.collected_fees).to eq(100)
@@ -150,6 +151,7 @@ RSpec.describe Facility do
     it 'collects 25 dollars when registering a car with :antique plates' do
       camaro = Vehicle.new({vin: '1a2b3c4d5e6f', year: 1969, make: 'Chevrolet', model: 'Camaro', engine: :ice})
 
+      @facility.plate_maker(camaro)
       @facility.fee_collector(camaro)
 
       expect(@facility.collected_fees).to eq(25)
@@ -158,9 +160,10 @@ RSpec.describe Facility do
     it 'collects 200 dollars when registering a car with :ev plates' do
       bolt = Vehicle.new({vin: '987654321abcdefgh', year: 2019, make: 'Chevrolet', model: 'Bolt', engine: :ev})
 
-      @facility.register_vehicle(bolt)
+      @facility.plate_maker(bolt)
+      @facility.fee_collector(bolt)
 
-      expect(bolt.collected_fees).to eq(:200)
+      expect(@facility.collected_fees).to eq(200)
     end
   end
 end

--- a/spec/facility_spec.rb
+++ b/spec/facility_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe Facility do
     it 'makes an antique plate when vehicle is over 25 years old' do
       camaro = Vehicle.new({vin: '1a2b3c4d5e6f', year: 1969, make: 'Chevrolet', model: 'Camaro', engine: :ice})
 
-      plate_maker(camaro)
+      @facility.plate_maker(camaro)
 
       expect(camaro.plate_type).to eq(:antique)
     end
@@ -82,7 +82,7 @@ RSpec.describe Facility do
     it 'makes an ev plate when vehicle is an ev engine' do
       bolt = Vehicle.new({vin: '987654321abcdefgh', year: 2019, make: 'Chevrolet', model: 'Bolt', engine: :ev})
 
-      plate_maker(bolt)
+      @facility.plate_maker(bolt)
 
       expect(bolt.plate_type).to eq(:ev)
     end
@@ -90,7 +90,7 @@ RSpec.describe Facility do
     it 'makes a regular plate when a vehicle is newer than 25 years and is not an ev engine' do
       cruz = Vehicle.new({vin: '123456789abcdefgh', year: 2012, make: 'Chevrolet', model: 'Cruz', engine: :ice})
 
-      plate_maker(cruz)
+      @facility.plate_maker(cruz)
 
       expect(cruz.plate_type).to eq(:regular)
     end
@@ -103,5 +103,4 @@ RSpec.describe Facility do
 
     #   expect(@facility.collected_fees).to eq(100)
     # end
-  end
 end

--- a/spec/registrant_spec.rb
+++ b/spec/registrant_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Registrant do
             
             registrant_1.earn_permit
 
-            expect(registrant_2.permit?).to eq(true)
+            expect(registrant_1.permit?).to eq(true)
         end
     end
 end

--- a/spec/vehicle_spec.rb
+++ b/spec/vehicle_spec.rb
@@ -33,4 +33,10 @@ RSpec.describe Vehicle do
       expect(@camaro.electric_vehicle?).to eq(false)
     end
   end
+
+  describe '#registration_date' do
+    it 'can tell you the registration date of an ev' do
+      expect(@cruz.registration_date).to eq(nil)
+    end
+  end
 end


### PR DESCRIPTION
This branch adds the following functionality:
- Adds register vehicle method to assign a plate type to vehicles based on different criteria (with a helper method)
- Adds to register vehicle method to charge appropriate fees based on same criteria (with a helper method)
- Adds to register vehicle method to give a vehicle a registration date 
- Adds to register vehicle method to track vehicles registered to a specific DMV location
